### PR TITLE
Fix editing from the current task name

### DIFF
--- a/src/components/Todo.js
+++ b/src/components/Todo.js
@@ -42,7 +42,7 @@ export default function Todo(props) {
           id={props.id}
           className="todo-text"
           type="text"
-          value={newName || props.name}
+          value={newName}
           onChange={handleChange}
           ref={editFieldRef}
         />
@@ -82,7 +82,7 @@ export default function Todo(props) {
         <button
           type="button"
           className="btn"
-          onClick={() => setEditing(true)}
+          onClick={() => {setName(props.name); setEditing(true)}}
           ref={editButtonRef}
           >
             Edit <span className="visually-hidden">{props.name}</span>


### PR DESCRIPTION
### Description

Fix editing from the current task name instead of from empty in the input field of the editing template.

### Motivation

#17 introduced editing from the current task name instead of from empty in the input field of the editing template. However this made it impossible to empty the input field (for instance by removing every character in the field with backspace) because when the last character is removed the field is automatically replaced with the current task name, which is unexpected for the user. This is because the component `value` attribute is set to `props.name` when the `name` state is empty.

This PR allows making the input field of the editing template empty again, while still allowing editing from the current task name instead of from empty. To do so, instead of the strategy used in #17, the `name` state of the `<Todo>` React component is set to `props.name` when the edit button is clicked.

### Related issues and pull requests

👉 Relates to #17