### PR TITLE
onChange Event Issue fixed

### DIFF
--- a/src/components/Todo.js
+++ b/src/components/Todo.js
@@ -42,7 +42,7 @@ export default function Todo(props) {
           id={props.id}
           className="todo-text"
           type="text"
-          value={newName || props.name}
+          value={isEditing ? newName : props.name}
           onChange={handleChange}
           ref={editFieldRef}
         />


### PR DESCRIPTION
### Description
When click on Edit on any Todo, It will be cleared and You can add a new todo.

### Motivation
I have added a condition in the input value.  If isEditing is true then use newName else use props.name

### Additional details
This change will help users edit existing todos.

### Related issues and pull requests
Fixes #77 

