### PR TITLE
[Fixed] onChange event issue

### DIFF
--- a/src/components/Todo.js
+++ b/src/components/Todo.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
 
-
 function usePrevious(value) {
   const ref = useRef();
   useEffect(() => {
@@ -11,7 +10,7 @@ function usePrevious(value) {
 
 export default function Todo(props) {
   const [isEditing, setEditing] = useState(false);
-  const [newName, setNewName] = useState('');
+  const [newName, setNewName] = useState("");
 
   const editFieldRef = useRef(null);
   const editButtonRef = useRef(null);
@@ -19,6 +18,14 @@ export default function Todo(props) {
   const wasEditing = usePrevious(isEditing);
 
   function handleChange(e) {
+    setNewName(e.target.value);
+  }
+
+  function handleBlur(e) {
+    if (e.target.value === "") {
+      setNewName(props.name);
+      return;
+    }
     setNewName(e.target.value);
   }
 
@@ -42,18 +49,17 @@ export default function Todo(props) {
           id={props.id}
           className="todo-text"
           type="text"
-          value={newName || props.name}
+          value={newName || ""}
           onChange={handleChange}
+          onBlur={handleBlur}
           ref={editFieldRef}
         />
       </div>
       <div className="btn-group">
-
         <button
           type="button"
           className="btn todo-cancel"
-          onClick={() => setEditing(false)}
-        >
+          onClick={() => setEditing(false)}>
           Cancel
           <span className="visually-hidden">renaming {props.name}</span>
         </button>
@@ -68,36 +74,33 @@ export default function Todo(props) {
   const viewTemplate = (
     <div className="stack-small">
       <div className="c-cb">
-          <input
-            id={props.id}
-            type="checkbox"
-            defaultChecked={props.completed}
-            onChange={() => props.toggleTaskCompleted(props.id)}
-          />
-          <label className="todo-label" htmlFor={props.id}>
-            {props.name}
-          </label>
-        </div>
-        <div className="btn-group">
+        <input
+          id={props.id}
+          type="checkbox"
+          defaultChecked={props.completed}
+          onChange={() => props.toggleTaskCompleted(props.id)}
+        />
+        <label className="todo-label" htmlFor={props.id}>
+          {props.name}
+        </label>
+      </div>
+      <div className="btn-group">
         <button
           type="button"
           className="btn"
           onClick={() => setEditing(true)}
-          ref={editButtonRef}
-          >
-            Edit <span className="visually-hidden">{props.name}</span>
-          </button>
-          <button
-            type="button"
-            className="btn btn__danger"
-            onClick={() => props.deleteTask(props.id)}
-          >
-            Delete <span className="visually-hidden">{props.name}</span>
-          </button>
-        </div>
+          ref={editButtonRef}>
+          Edit <span className="visually-hidden">{props.name}</span>
+        </button>
+        <button
+          type="button"
+          className="btn btn__danger"
+          onClick={() => props.deleteTask(props.id)}>
+          Delete <span className="visually-hidden">{props.name}</span>
+        </button>
+      </div>
     </div>
   );
-
 
   useEffect(() => {
     if (!wasEditing && isEditing) {
@@ -107,7 +110,6 @@ export default function Todo(props) {
       editButtonRef.current.focus();
     }
   }, [wasEditing, isEditing]);
-
 
   return <li className="todo">{isEditing ? editingTemplate : viewTemplate}</li>;
 }


### PR DESCRIPTION
### 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster.

- When Erasing an entire word or sentence (value) from the Input, causes a reoccurrence of that word or sentence (value)

### ✍️ Summarize your changes in one or two sentences

- To let the user add an entirely new word or sentence (value) in input, I used the onBlur event,
- This onBlur event will only setNewName based on the current event value onBlur.
- If the value is Empty, we are setting `props.name` as it is the default.
- else we keep the setNewName to the value coming from the onBlur event.

### ❓ Why are you making these changes and how do they help?

- User or Learner now can easily change the word or sentence (value) of the input.

### 🔗 Link to documentation, bug trackers, source control, or other places providing more context 

https://github.com/mdn/todo-react/assets/112304655/400b0cd9-5327-4a96-b0c3-8a8034ae5ece

### Related issues and pull requests

Fixes #77
