### PR TITLE
fix(gh-pages): build dir is now 'dist', add yarn caching and nvmrc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Build
         uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: "npm"
+          node-version-file: ".nvmrc"
+          cache: "yarn"
       - name: Run install
         uses: borales/actions-yarn@v4
         with:
@@ -47,8 +47,8 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload build directory
-          path: "build"
+          # Upload dist directory
+          path: "dist"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Some changes breaking GitHub pages deploy after https://github.com/mdn/todo-react/pull/97

__failing builds:__

- https://github.com/mdn/todo-react/actions/workflows/deploy.yml

Logs:

```
Run actions/upload-pages-artifact@v3
  with:
    path: build
    name: github-pages
    retention-days: 1
  env:
    GITHUB_PAGES: true
Run tar \
  tar \
    --dereference --hard-dereference \
    --directory "$INPUT_PATH" \
    -cvf "$RUNNER_TEMP/artifact.tar" \
    --exclude=.git \
    --exclude=.github \
    .
  shell: /usr/bin/sh -e {0}
  env:
    GITHUB_PAGES: true
    INPUT_PATH: build
tar: build: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
Error: Process completed with exit code 2.
```