### PR TITLE
Fix base path error

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: "https://mdn.github.io/todo-react/"
 })


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Live application is failing to load on gh-pages with the following error:

"Loading module from “https://mdn.github.io/assets/index-u64nDbB7.js” was blocked because of a disallowed MIME type (“text/html”).
[todo-react](https://mdn.github.io/todo-react/)
Loading failed for the module with source “https://mdn.github.io/assets/index-u64nDbB7.js”."

This looks to be because the base path is not defined in the vite config.

Fixes https://github.com/mdn/todo-react/issues/102

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
