### PR TITLE
feat: change heading based on filter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,7 +84,7 @@ function App(props) {
   }
 
   const tasksNoun = taskList.length !== 1 ? "tasks" : "task";
-  const headingText = `${taskList.length} ${tasksNoun}`;
+  let headingText = `${taskList.length} ${tasksNoun}`;
   if (filter === "Active") headingText += " remaining";
   if (filter === "Completed") headingText += " completed";
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,7 +84,9 @@ function App(props) {
   }
 
   const tasksNoun = taskList.length !== 1 ? "tasks" : "task";
-  const headingText = `${taskList.length} ${tasksNoun} remaining`;
+  const headingText = `${taskList.length} ${tasksNoun}`;
+  if (filter === "Active") headingText += " remaining";
+  if (filter === "Completed") headingText += " completed";
 
   const listHeadingRef = useRef(null);
   const prevTaskLength = usePrevious(tasks.length);


### PR DESCRIPTION
### Description

Change the heading text so that it reflects the current tab. Previously, all tabs said "remaining", now they say:

- All: "N tasks"
- Active: "N tasks remaining" (same as before)
- Completed: "N tasks completed"

### Motivation

I started using this and was confused that when I went to my completed tasks, it said those tasks were still "remaining". All the tab filters say "remaining" but I think of "remaining" tasks as the tasks still left to do, not the completed ones. Now the header text appropriately reflects the active filter.

### Additional details

None

### Related issues and pull requests

None
